### PR TITLE
[finishes 163687996] add retrieve party route endpoint

### DIFF
--- a/api/admin/party/parties.py
+++ b/api/admin/party/parties.py
@@ -65,6 +65,6 @@ def get_party(Id):
     if party:
         return jsonify({
             "party" : party,
-            "success" : "party was returned",
+            "success" : "request was successful and a result was returned",
     }) 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -13,7 +13,6 @@ class BaseTest(unittest.TestCase):
         
         #a dictionary containing a party
         self.party = {
-                "Id" : "1",
                 "name" : "ANC",
                 "hqAddress" : "Kakamega",
                 "logoUrl" : "https://goo.gl/images/B9U4PK",
@@ -22,19 +21,16 @@ class BaseTest(unittest.TestCase):
         #a list of containing dictionaries containing parties
         self.parties = [
             {
-                "Id" : "1",
                 "name" : "ANC",
                 "hqAddress" : "Kakamega",
                 "logoUrl" : "https://goo.gl/images/B9U4PK",
             },
             {
-                "Id" : "2",
                 "name" : "Jubilee",
                 "hqAddress" : "Muthaiga",
                 "logoUrl" : "https://goo.gl/images/7hU72H",
             },
             {
-                "Id" : "3",
                 "name" : "Maendeleo Chapchap",
                 "hqAddress" : "Machakos",
                 "logoUrl" : "https://goo.gl/images/3RKgQ6",
@@ -53,7 +49,7 @@ class BaseTest(unittest.TestCase):
             self.assertEqual(response.status_code, 201)
             self.assertIn('ANC was added', data['success'])
 
-    def get_parties(self):
+    def test_get_parties(self):
         """a list of political parties is returned."""
         with self.client:
             response = self.client.get(


### PR DESCRIPTION
**What does this PR do?**
 -Adds a feature for the user to retrieve a particular political party

**Description of Task to be completed?**
- A political party is retrieved by sending a **GET** request to the endpoint _127.0.0.1:500/api/v1/parties/1_ ;

- A response with a payload of the form below is returned if successful

```{
    "data": {
        "Id": 1,
        "hqAddress": "Muthaiga",
        "logoUrl": "https://goo.gl/images/7hU72H",
        "name": "Jubilee"
    },
    "status": 201,
    "success": "party Jubilee was retrieved"
}
```
- A response with a payload of the form below is returned if the request is not successful 

   ```
      {
            “status” : 400 ,
            “error” : "retrieving the party failed”
      }
   ```

**How should the app be tested?**
-Via a web browser.
-First of all, ensure you install Postman - Test client to test the API endpoint.

[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/55e0954df1faa13e63ad) via your web browser.

**What are the relevant pivotal tracker stories**
https://www.pivotaltracker.com/n/projects/2241887/stories/163687996




